### PR TITLE
Implement user validation and CRUD

### DIFF
--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -2,16 +2,27 @@ security:
     # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
     password_hashers:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
+        App\Entity\AppUser: 'auto'
     # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
     providers:
         users_in_memory: { memory: null }
+        app_user_provider:
+            entity:
+                class: App\Entity\AppUser
+                property: email
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             lazy: true
-            provider: users_in_memory
+            provider: app_user_provider
+
+        api:
+            pattern: ^/api
+            stateless: true
+            provider: app_user_provider
+            jwt: ~
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#the-firewall
@@ -24,6 +35,9 @@ security:
     access_control:
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }
+        - { path: ^/api/login_check, roles: PUBLIC_ACCESS }
+        - { path: ^/api/register, roles: PUBLIC_ACCESS }
+        - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }
 
 when@test:
     security:

--- a/backend/config/validator/validation.yaml
+++ b/backend/config/validator/validation.yaml
@@ -1,23 +1,36 @@
 # config/validator/validation.yaml
 
 App\Entity\AppUser:
+  constraints:
+    - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
+        fields: ["email"]
+        message: "Email is already registered."
   properties:
     username:
-      - NotBlank: ~
+      - NotBlank:
+          message: "Username is required."
       - Length:
           max: 180
+          maxMessage: "Username cannot exceed {{ limit }} characters."
     email:
-      - NotBlank: ~
-      - Email: ~
+      - NotBlank:
+          message: "Email is required."
+      - Email:
+          message: "Please provide a valid email address."
       - Length:
           max: 180
+          maxMessage: "Email cannot exceed {{ limit }} characters."
     password:
-      - NotBlank: ~
+      - NotBlank:
+          message: "Password is required."
       - Length:
-          min: 6
+          min: 8
+          minMessage: "Password must be at least {{ limit }} characters long."
           max: 255
+          maxMessage: "Password cannot exceed {{ limit }} characters."
     roles:
-      - NotNull: ~
+      - NotNull:
+          message: "Roles cannot be null."
 
 App\Entity\AuditLog:
   properties:

--- a/backend/src/Controller/UserController.php
+++ b/backend/src/Controller/UserController.php
@@ -97,4 +97,50 @@ class UserController extends AbstractController
         }
         return $this->json(['newPassword'=>$new]);
     }
+
+    #[Route('', name: 'user_list', methods: ['GET'])]
+    public function listUsers(): JsonResponse
+    {
+        $users = $this->usersvc->listUsers();
+        $data = array_map(fn($u) => [
+            'id' => $u->getId(),
+            'username' => $u->getUsername(),
+            'email' => $u->getEmail(),
+            'locked' => $u->isLocked(),
+        ], $users);
+        return $this->json($data);
+    }
+
+    #[Route('/{id}', name: 'user_get', methods: ['GET'])]
+    public function getUserById(int $id): JsonResponse
+    {
+        $user = $this->usersvc->getUser($id);
+        if (!$user) {
+            return $this->json(['error' => 'User not found'], 404);
+        }
+
+        return $this->json([
+            'id' => $user->getId(),
+            'username' => $user->getUsername(),
+            'email' => $user->getEmail(),
+            'locked' => $user->isLocked(),
+        ]);
+    }
+
+    #[Route('/{id}', name: 'user_delete', methods: ['DELETE'])]
+    public function deleteUser(int $id): JsonResponse
+    {
+        // Placeholder for future RBAC checks
+        if (!$this->isGranted('ROLE_ADMIN')) {
+            return $this->json(['error' => 'Forbidden'], 403);
+        }
+
+        try {
+            $this->usersvc->deleteUser($id);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json(['error' => $e->getMessage()], 404);
+        }
+
+        return new JsonResponse(null, 204);
+    }
 }

--- a/backend/src/Entity/AppUser.php
+++ b/backend/src/Entity/AppUser.php
@@ -7,9 +7,10 @@ use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
 #[ORM\Entity(repositoryClass: AppUserRepository::class)]
-class AppUser implements UserInterface
+class AppUser implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/backend/src/Service/UserService.php
+++ b/backend/src/Service/UserService.php
@@ -110,4 +110,38 @@ class UserService
 
         return $newPass;
     }
+
+    /**
+     * Remove a user from the system.
+     *
+     * @throws \InvalidArgumentException when the user does not exist.
+     */
+    public function deleteUser(int $id): void
+    {
+        $user = $this->repo->find($id);
+        if (!$user) {
+            throw new \InvalidArgumentException('User not found.');
+        }
+
+        $this->em->remove($user);
+        $this->em->flush();
+    }
+
+    /**
+     * Retrieve all users.
+     *
+     * @return AppUser[]
+     */
+    public function listUsers(): array
+    {
+        return $this->repo->findAll();
+    }
+
+    /**
+     * Get a single user by id.
+     */
+    public function getUser(int $id): ?AppUser
+    {
+        return $this->repo->find($id);
+    }
 }


### PR DESCRIPTION
## Summary
- enforce email uniqueness and stronger password rules in validation
- implement PasswordAuthenticatedUserInterface for AppUser
- expand UserService with list, get and delete helpers
- expose user CRUD endpoints for listing, getting and deleting users
- tighten security configuration for API with JWT auth

## Testing
- `composer install --ignore-platform-req=ext-sodium`
- `php -l src/Entity/AppUser.php`
- `php -l src/Service/UserService.php`
- `php -l src/Controller/UserController.php`
- `php bin/console debug:router`

