### PR TITLE
Fix: Add/fix event and listener placeholders for all required classes

### DIFF
--- a/backend/src/EventListener/AuditLoggedListener.php
+++ b/backend/src/EventListener/AuditLoggedListener.php
@@ -3,6 +3,9 @@ namespace App\EventListener;
 
 class AuditLoggedListener
 {
-    // ...
+    public function onAuditLogged($event): void
+    {
+        // Placeholder
+    }
 }
 

--- a/backend/src/EventListener/InventoryLotCreatedListener.php
+++ b/backend/src/EventListener/InventoryLotCreatedListener.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\EventListener;
+
+class InventoryLotCreatedListener
+{
+    public function onInventoryLotCreated($event): void
+    {
+        // Placeholder
+    }
+}

--- a/backend/src/EventListener/InventoryTransactionLoggedListener.php
+++ b/backend/src/EventListener/InventoryTransactionLoggedListener.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\EventListener;
+
+class InventoryTransactionLoggedListener
+{
+    public function onInventoryTransactionLogged($event): void
+    {
+        // Placeholder
+    }
+}

--- a/backend/src/EventListener/MaintenanceListener.php
+++ b/backend/src/EventListener/MaintenanceListener.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\EventListener;
+
+class MaintenanceListener
+{
+    public function onMaintenanceScheduled($event): void
+    {
+        // Placeholder
+    }
+
+    public function onMaintenanceCompleted($event): void
+    {
+        // Placeholder
+    }
+
+    public function onMaintenanceSkipped($event): void
+    {
+        // Placeholder
+    }
+}

--- a/backend/src/EventListener/ProductionWorkflowListener.php
+++ b/backend/src/EventListener/ProductionWorkflowListener.php
@@ -1,0 +1,40 @@
+<?php
+namespace App\EventListener;
+
+class ProductionWorkflowListener
+{
+    public function onBatchSown($event): void
+    {
+        // Placeholder
+    }
+
+    public function onTrayRowMoved($event): void
+    {
+        // Placeholder
+    }
+
+    public function onTrayRowRetrayed($event): void
+    {
+        // Placeholder
+    }
+
+    public function onTrayRowSplit($event): void
+    {
+        // Placeholder
+    }
+
+    public function onHarvestLogged($event): void
+    {
+        // Placeholder
+    }
+
+    public function onBatchClosed($event): void
+    {
+        // Placeholder
+    }
+
+    public function onBatchDestroyed($event): void
+    {
+        // Placeholder
+    }
+}

--- a/backend/src/EventListener/UserCreatedListener.php
+++ b/backend/src/EventListener/UserCreatedListener.php
@@ -3,5 +3,8 @@ namespace App\EventListener;
 
 class UserCreatedListener
 {
-    // No methods or logic yet. Placeholder only.
+    public function onUserCreated($event): void
+    {
+        // Placeholder
+    }
 }

--- a/backend/src/EventListener/UserLoginListener.php
+++ b/backend/src/EventListener/UserLoginListener.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\EventListener;
+
+class UserLoginListener
+{
+    public function onUserLogin($event): void
+    {
+        // Placeholder
+    }
+}

--- a/backend/src/EventListener/UserLogoutListener.php
+++ b/backend/src/EventListener/UserLogoutListener.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\EventListener;
+
+class UserLogoutListener
+{
+    public function onUserLogout($event): void
+    {
+        // Placeholder
+    }
+}


### PR DESCRIPTION
## Summary
- add placeholder listeners with basic method stubs
- ensure all event listeners have namespaces/classes matching filenames

## Testing
- `composer validate --no-check-all`
- `find backend/src -name '*.php' -print0 | xargs -0 -n1 php -l`

